### PR TITLE
allow changing output name or suppressing it

### DIFF
--- a/pandoc_source_exec.py
+++ b/pandoc_source_exec.py
@@ -372,7 +372,13 @@ def action(elem, doc):  # noqa
                 else:
                     block = pf.CodeBlock(result, classes=['changelog'])
 
-                elems += [pf.Para(pf.Emph(pf.Str('Output:'))), block]
+                output_label = 'Output:'
+                if 'output_label' in elem.attributes:
+                    output_label = elem.attributes['output_label']
+                if output_label != '':
+                    elems += [pf.Para(pf.Emph(pf.Str(output_label))), block]
+                else:
+                    elems += [block]
 
         if 'lines' in elem.attributes:
             elem.text = filter_lines(elem.text, elem.attributes['lines'])


### PR DESCRIPTION
fixes #11 (see discussion there)

@shoeffner the intention is to keep complete backwards compatibility, so default for `output_label` is "Output:", but it can be changed or set to empty string '' (thus being completely removed during filter process).

I tried locally, manually edited the pip installed version and tried with four scenarios (see issue), changing language, supressing, and combining with hidden option... if you think there are more corner cases to be tested, we can see. Regards!